### PR TITLE
新增调用代码定位时可跳过指定方法数

### DIFF
--- a/app/src/main/java/com/hjq/toast/demo/MainActivity.java
+++ b/app/src/main/java/com/hjq/toast/demo/MainActivity.java
@@ -209,4 +209,17 @@ public final class MainActivity extends AppCompatActivity {
                 .setWindowLocation(Gravity.BOTTOM, 0, (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 50, getResources().getDisplayMetrics()))
                 .show();
     }
+
+    public void skipStacks(View v) {
+        toastTraceAndSkipStacks(getString(R.string.demo_show_toast_with_trace_and_skip_stacks_result));
+    }
+
+    // 在封装的方法使用 Toaster 时，打印的栈信息跳过指定调用层数
+    void toastTraceAndSkipStacks(String message) {
+        ToastParams params = new ToastParams();
+        params.text = message;
+        params.stackSkips = 1; // 根据实际情况调整层数
+        Toaster.show(params);
+    }
+
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -178,6 +178,14 @@
                     android:onClick="combinationEasyWindowShow"
                     android:text="@string/demo_combining_window_framework_use" />
 
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginTop="10dp"
+                    android:onClick="skipStacks"
+                    android:text="@string/demo_show_toast_with_trace_and_skip_stacks" />
+
             </LinearLayout>
 
         </FrameLayout>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -19,6 +19,7 @@
     <string name="demo_click_show_three_toast">点我连续显示 3 个 Toast</string>
     <string name="demo_show_toast_in_background_state">在后台状态下显示 Toast</string>
     <string name="demo_combining_window_framework_use">搭配 EasyWindow 悬浮窗框架</string>
+    <string name="demo_show_toast_with_trace_and_skip_stacks">调用代码定位和跳过堆栈</string>
 
     <string name="demo_show_toast_result">我是普通的 Toast</string>
     <string name="demo_show_short_toast_result">我是一个短 Toast</string>
@@ -42,4 +43,5 @@
     <string name="demo_show_toast_in_background_state_result_2">我是在后台显示的 Toast（安卓 11 及以上在后台显示只能使用系统样式）</string>
     <string name="demo_show_toast_in_background_state_result_3">我是在后台显示的 Toast</string>
     <string name="demo_combining_window_framework_use_result">就问你溜不溜</string>
+    <string name="demo_show_toast_with_trace_and_skip_stacks_result">我会在 Logcat 中打印一条日志，定位和跳过指定堆栈数</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="demo_click_show_three_toast">Click and I show 3 toast in a row</string>
     <string name="demo_show_toast_in_background_state">Show toast in background state</string>
     <string name="demo_combining_window_framework_use">Combining EasyWindow suspension window frames</string>
+    <string name="demo_show_toast_with_trace_and_skip_stacks">Call code trace and skip stacks</string>
 
     <string name="demo_show_toast_result">I am an normal toast</string>
     <string name="demo_show_short_toast_result">I am a short toast</string>
@@ -43,4 +44,5 @@
     <string name="demo_show_toast_in_background_state_result_2">I am displaying the toast in the background (Android 11 and above can only use the system style in the background display)</string>
     <string name="demo_show_toast_in_background_state_result_3">I am displaying toast in the background</string>
     <string name="demo_combining_window_framework_use_result">Hello Word</string>
+    <string name="demo_show_toast_with_trace_and_skip_stacks_result">I will print a log in Logcat, trace and skip stacks</string>
 </resources>

--- a/library/src/main/java/com/hjq/toast/ToastLogInterceptor.java
+++ b/library/src/main/java/com/hjq/toast/ToastLogInterceptor.java
@@ -16,17 +16,20 @@ public class ToastLogInterceptor implements IToastInterceptor {
 
     @Override
     public boolean intercept(ToastParams params) {
-        printToast(params.text);
+        int stackSkips = params.stackSkips;
+        printToast(params.text, stackSkips);
         return false;
     }
 
-    protected void printToast(CharSequence text) {
+    protected void printToast(CharSequence text, int stackSkips) {
         if (!isLogEnable()) {
             return;
         }
 
         // 获取调用的堆栈信息
         StackTraceElement[] stackTraces = new Throwable().getStackTrace();
+        // 跳过方法调用层数的计数器
+        int currentSkips = 0;
         for (StackTraceElement stackTrace : stackTraces) {
             // 获取代码行数
             int lineNumber = stackTrace.getLineNumber();
@@ -39,6 +42,12 @@ public class ToastLogInterceptor implements IToastInterceptor {
             try {
                 Class<?> clazz = Class.forName(className);
                 if (!filterClass(clazz)) {
+                    // 跳过指定层数方法调用
+                    if (currentSkips < stackSkips) {
+                        currentSkips++;
+                        continue;
+                    }
+                    // 打印日志
                     printLog("(" + stackTrace.getFileName() + ":" + lineNumber + ") " + text.toString());
                     // 跳出循环
                     break;

--- a/library/src/main/java/com/hjq/toast/ToastLogInterceptor.java
+++ b/library/src/main/java/com/hjq/toast/ToastLogInterceptor.java
@@ -16,8 +16,7 @@ public class ToastLogInterceptor implements IToastInterceptor {
 
     @Override
     public boolean intercept(ToastParams params) {
-        int stackSkips = params.stackSkips;
-        printToast(params.text, stackSkips);
+        printToast(params.text, params.stackSkips);
         return false;
     }
 

--- a/library/src/main/java/com/hjq/toast/ToastParams.java
+++ b/library/src/main/java/com/hjq/toast/ToastParams.java
@@ -30,6 +30,11 @@ public class ToastParams {
      */
     public int duration = -1;
 
+    /**
+     * 打印调用栈时，跳过的方法数
+     */
+    public int stackSkips = 0;
+
     /** 延迟显示时间 */
     public long delayMillis = 0;
 


### PR DESCRIPTION
场景：在实际项目上，可能有业务埋点需要，或者有从另一个 Toast 框架迁移到 Toater 等情况，会将 Toaster 进行一层或多层封装

问题：目前 Toaster 的代码定位始终追踪到 Toater 调用处，多加一层方法就只会定位在封装的方法中

解决：修改源码新增控制参数，可以跳过指定的调用方法层数，再打印调用代码定位

当前版本，堆栈追踪打印位置
```
button.setOnClickListener {
    toast("I am a message")
}

fun toast(message: String) {
    Toaster.show(message) // 打印定位在此处
    // do something
    // ...
}
```

修改版本，堆栈追踪打印位置
```
button.setOnClickListener {
    toast("I am a message") // 打印定位在此处
}

fun toast(message: String) {
    val params = ToastParams().apply {
        text = message
        stackSkips = 1 // 根据实际情况调整层数
    }
    Toaster.show(params)
    // do something
    // ...
}
```
